### PR TITLE
Pipeline clean up

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,14 @@
 node("launchpad-maven") {
-  checkout scm
-  stage("Build") {
-    sh "mvn fabric8:deploy -Popenshift -DskipTests"
-  }
-  stage("Deploy")
+
+   stage "Checkout"
+        checkout scm
+
+   stage "Standalone Integration Tests"
+        sh "mvn clean verify"
+
+   stage "OpenShift Integration Tests"
+        sh "mvn clean verify -Popenshift -Dskip.surefire.tests=true"
+
+   stage "Deploy"
+        sh "mvn fabric8:apply -Popenshift"
 }

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,10 @@
     <maven-failsafe-plugin.version>2.19.1</maven-failsafe-plugin.version>
     <vertx-maven-plugin.version>1.0.6</vertx-maven-plugin.version>
 
+    <skipTests>false</skipTests>
+    <skip.surefire.tests>${skipTests}</skip.surefire.tests>
+    <skip.failsafe.tests>${skipTests}</skip.failsafe.tests>
+
     <vertx.verticle>io.openshift.booster.HttpApplication</vertx.verticle>
   </properties>
 
@@ -115,6 +119,13 @@
   <build>
     <plugins>
       <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.14</version>
+        <configuration>
+          <skipTests>${skip.surefire.tests}</skipTests>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.6.1</version>
@@ -171,7 +182,6 @@
       </plugins>
     </pluginManagement>
   </build>
-
   <profiles>
     <profile>
       <id>openshift</id>
@@ -191,17 +201,16 @@
               </execution>
             </executions>
           </plugin>
-        </plugins>
-      </build>
-    </profile>
-    <profile>
-      <id>openshift-it</id>
-      <build>
-        <plugins>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-failsafe-plugin</artifactId>
             <version>${maven-failsafe-plugin.version}</version>
+            <configuration>
+              <includes>
+                <include>**/**OST.java</include>
+              </includes>
+              <skipTests>${skip.failsafe.tests}</skipTests>
+            </configuration>
             <executions>
               <execution>
                 <goals>

--- a/src/openshift/openshift-pipeline-template.yml
+++ b/src/openshift/openshift-pipeline-template.yml
@@ -15,7 +15,7 @@ parameters:
   description: The source URL for the application
   displayName: Source URL
   required: true
-  value: https://github.com/openshiftio-vertx-bootsters/vertx-http-bootster.git
+  value: https://github.com/openshiftio-vertx-boosters/vertx-http-booster.git
 - name: GIT_SOURCE_REF
   description: The source Ref for the application
   displayName: Source Ref
@@ -36,29 +36,15 @@ parameters:
 
 ##
 # Objects created by the template:
-# * An image stream containing the application
 # * A build config using the pipeline strategy
-# * A deployment config / replication controller instantiating 1 instance of the application
-# * A service to make the application available to other application running in OpenShift
-# * A route making the application accessible from outside OpenShift
 ##
 objects:
-
-- apiVersion: v1
-  kind: ImageStream
-  metadata:
-    labels:
-      app: ${APP_NAME}
-    name: ${APP_NAME}
-  spec: {}
-  status:
-    dockerImageRepository: ""
 
 - apiVersion: v1
   kind: BuildConfig
   metadata:
     annotations:
-      pipeline.alpha.openshift.io/uses: '[{"name": "${NAME}", "namespace": "", "kind": "DeploymentConfig"}]'
+      pipeline.alpha.openshift.io/uses: '[{"name": "${APP_NAME}", "namespace": "", "kind": "DeploymentConfig"}]'
     creationTimestamp: null
     labels:
       name: ${APP_NAME}
@@ -68,6 +54,8 @@ objects:
       type: "Git"
       git:
         uri: "${GIT_SOURCE_URL}"
+        ref: "${GIT_SOURCE_REF}"
+
     strategy:
       type: JenkinsPipeline
       jenkinsPipelineStrategy:
@@ -79,110 +67,3 @@ objects:
     - generic:
         secret: "${GENERIC_WEBHOOK_SECRET}"
       type: Generic
-      
-- apiVersion: v1
-  kind: DeploymentConfig
-  metadata:
-    labels:
-      app: ${APP_NAME}
-    name: ${APP_NAME}
-  spec:
-    replicas: 1
-    selector:
-      app: ${APP_NAME}
-      deploymentconfig: ${APP_NAME}
-    strategy:
-      rollingParams:
-        intervalSeconds: 1
-        maxSurge: 25%
-        maxUnavailable: 25%
-        timeoutSeconds: 600
-        updatePeriodSeconds: 1
-      type: Rolling
-    template:
-      metadata:
-        labels:
-          app: ${APP_NAME}
-          deploymentconfig: ${APP_NAME}
-      spec:
-        containers:
-        - image: ${APP_NAME}:latest
-          imagePullPolicy: Always
-          name: ${APP_NAME}
-          ports:
-          - containerPort: 8080
-            protocol: TCP
-          resources: {}
-          terminationMessagePath: /dev/termination-log
-          livenessProbe:
-            httpGet:
-              path: /api/greeting
-              port: 8080
-              scheme: HTTP
-            initialDelaySeconds: 10
-            timeoutSeconds: 2
-            periodSeconds: 10
-            successThreshold: 1
-            failureThreshold: 3
-          readinessProbe:
-            httpGet:
-              path: /api/greeting
-              port: 8080
-              scheme: HTTP
-            initialDelaySeconds: 30
-            timeoutSeconds: 2
-            periodSeconds: 10
-            successThreshold: 1
-            failureThreshold: 3
-        dnsPolicy: ClusterFirst
-        restartPolicy: Always
-        securityContext: {}
-        terminationGracePeriodSeconds: 30
-    test: false
-    triggers:
-    - type: ConfigChange
-    - imageChangeParams:
-        automatic: true
-        containerNames:
-        - ${APP_NAME}
-        from:
-          kind: ImageStreamTag
-          name: ${APP_NAME}:latest
-      type: ImageChange
-  
-- apiVersion: v1
-  kind: Service
-  metadata:
-    annotations:
-      openshift.io/generated-by: OpenShiftNewApp
-    labels:
-      app: ${APP_NAME}
-    name: ${APP_NAME}
-  spec:
-    ports:
-    - name: http
-      port: 8080
-      protocol: TCP
-      targetPort: 8080
-    selector:
-      app: ${APP_NAME}
-      deploymentconfig: ${APP_NAME}
-    sessionAffinity: None
-    type: ClusterIP
-  status:
-    loadBalancer: {}
-
-- apiVersion: v1
-  kind: Route
-  metadata:
-    name: ${APP_NAME}
-    labels:
-      app: ${APP_NAME}
-  spec:
-    to:
-      kind: Service
-      name: ${APP_NAME}
-      weight: 100
-    port:
-      targetPort: 8080
-    wildcardPolicy: None

--- a/src/test/java/io/openshift/booster/HttpApplicationOST.java
+++ b/src/test/java/io/openshift/booster/HttpApplicationOST.java
@@ -17,7 +17,7 @@ import static org.hamcrest.core.IsEqual.equalTo;
  * @author <a href="http://escoffier.me">Clement Escoffier</a>
  */
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
-public class OpenShiftIT {
+public class HttpApplicationOST {
 
     private static OpenShiftTestAssistant assistant = new OpenShiftTestAssistant();
 


### PR DESCRIPTION
Hey,
here is my proposal of Jenkins pipeline. I also did some clean up which I think better demonstrates the pipeline.

* Remove unncessary objects which are created by FMP automatically
* Separate OpenShift Integration Tests and Standalone Integration Test build to two profiles. (Standalone are active by default)