### PR TITLE
fix(version no): removed the version of fabric8-maven-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,6 @@
           <plugin>
             <groupId>io.fabric8</groupId>
             <artifactId>fabric8-maven-plugin</artifactId>
-            <version>3.5.33</version>
             <executions>
               <execution>
                 <id>fmp</id>


### PR DESCRIPTION
the latest version no of fabric8-maven-plugin is already updated in the parent booster-parent repo. hence removed from the child repo.