### PR TITLE
Improve OpenshiftIT 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,8 +81,8 @@
 
     <dependency>
       <groupId>org.jboss.arquillian.junit</groupId>
-      <artifactId>arquillian-junit-container</artifactId>
-      <version>1.1.12.Final</version>
+      <artifactId>arquillian-junit-standalone</artifactId>
+      <version>1.4.0.Final</version>
       <scope>test</scope>
     </dependency>
 
@@ -101,7 +101,7 @@
     <dependency>
       <groupId>io.fabric8</groupId>
       <artifactId>openshift-client</artifactId>
-      <version>1.4.34</version>
+      <version>3.1.10</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/test/java/io/openshift/booster/OpenShiftIT.java
+++ b/src/test/java/io/openshift/booster/OpenShiftIT.java
@@ -1,39 +1,23 @@
 package io.openshift.booster;
 
 import com.jayway.restassured.RestAssured;
-import io.fabric8.kubernetes.api.model.Pod;
-import io.fabric8.openshift.client.OpenShiftClient;
-import org.arquillian.cube.kubernetes.api.Session;
+import java.net.MalformedURLException;
+import java.net.URL;
 import org.arquillian.cube.openshift.impl.enricher.AwaitRoute;
 import org.arquillian.cube.openshift.impl.enricher.RouteURL;
 import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.arquillian.test.api.ArquillianResource;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
-
 import static com.jayway.restassured.RestAssured.get;
 import static io.openshift.booster.HttpApplication.template;
-import static org.awaitility.Awaitility.await;
 import static org.hamcrest.core.IsEqual.equalTo;
 
 @RunWith(Arquillian.class)
 public class OpenShiftIT {
-    private String project;
 
     private final String applicationName = System.getProperty("app.name", "http-vertx");
-    
-    @ArquillianResource
-    private OpenShiftClient client;
-    
-    @ArquillianResource
-    private Session session;
 
     @RouteURL("${app.name}")
     @AwaitRoute
@@ -42,32 +26,18 @@ public class OpenShiftIT {
     @Before
     public void setup() {
         RestAssured.baseURI = route.toString();
-        project = this.client.getNamespace();
     }
 
     @Test
     public void testThatWeAreReady() throws Exception {
-        await().atMost(5, TimeUnit.MINUTES).until(() -> {
-                List<Pod> list = client.pods().inNamespace(project).list().getItems();
-                return list.stream()
-                    .filter(pod -> pod.getMetadata().getName().startsWith(applicationName))
-                    .filter(this::isRunning)
-                    .collect(Collectors.toList()).size() >= 1;
-            }
-        );
         // Check that the route is served.
-        await().atMost(5, TimeUnit.MINUTES).catchUncaughtExceptions().until(() -> get().getStatusCode() < 500);
-        await().atMost(5, TimeUnit.MINUTES).catchUncaughtExceptions().until(() -> get("/api/greeting")
-            .getStatusCode() < 500);
+        get().then().statusCode(equalTo(200));
+        get("/api/greeting").then().statusCode(equalTo(200));
     }
 
     @Test
     public void testThatWeServeAsExpected() throws MalformedURLException {
         get("/api/greeting").then().body("content", equalTo(String.format(template, "World")));
         get("/api/greeting?name=vert.x").then().body("content", equalTo(String.format(template, "vert.x")));
-    }
-
-    private boolean isRunning(Pod pod) {
-        return "running".equalsIgnoreCase(pod.getStatus().getPhase());
     }
 }


### PR DESCRIPTION
**Changes introduced in the PR**
* Adds correct dependency for standalone mode
 In OpenshiftIT, we are not doing any deployment using `@Deployment` method inside openshiftIT, due to which we should use `arquillian-junit-standalone` dependency instead of `arquillian-junit-container`
* Removes unnecessary code from OpenshiftIT
* Version updates
  - arquillian core to use latest i.e. `1.4.0.Final`
  - openshift-client to use latest i.e. `3.1.10`

cc @Ladicek, @bartoszmajsak